### PR TITLE
[feat] 타임캡슐 메인·사진등록 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^7.3.21",
     "nativewind": "^2.0.11",
-    "react": "18.2.0",
+    "react": "19.0.0",
     "react-dom": "18.2.0",
     "react-native": "0.79.3",
     "react-native-gesture-handler": "^2.27.1",

--- a/src/screens/CapsuleMainPage.tsx
+++ b/src/screens/CapsuleMainPage.tsx
@@ -1,11 +1,79 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 
-export default function CapsuleMainPage() {
+const BUTTON_WIDTH = 300;
+const PREVIEW_SIZE = 200;
 
+const CapsuleMainPage = () => {
   return (
-    <View>
-      <Text>타임캡슐-메인페이지</Text>
+    <View style={styles.container}>
+      <View style={styles.headerWrapper}>
+        <Text style={styles.title}>
+          세상에 단 하나뿐인{'\n'}타임캡슐을 만들어보세요
+        </Text>
+        <Text style={styles.subtitle}>
+          IPFS 기술로 안전하게 보관되어{'\n'}수십 년이 지나도 그대로 간직될 수 있어요
+        </Text>
+      </View>
+
+      <View style={styles.previewBox} />
+
+      <TouchableOpacity
+        style={styles.button}
+        activeOpacity={0.8}
+        accessibilityLabel="타임캡슐 시작하기"
+      >
+        <Text style={styles.buttonText}>시작하기</Text>
+      </TouchableOpacity>
     </View>
   );
-}
+};
+
+export default CapsuleMainPage;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    backgroundColor: 'white',
+  },
+  headerWrapper: {
+    marginTop: 200,
+    marginBottom: 48,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    lineHeight: 32,
+    marginBottom: 16,
+    color: '#000',
+  },
+  subtitle: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: 'gray',
+  },
+  previewBox: {
+    width: PREVIEW_SIZE,
+    height: PREVIEW_SIZE,
+    backgroundColor: '#E0E0E0',
+    borderRadius: 20,
+    alignSelf: 'center',
+    marginVertical: 40,
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignSelf: 'center',
+    width: BUTTON_WIDTH,
+    marginTop: 20,
+    marginBottom: 20,
+  },
+  buttonText: {
+    textAlign: 'center',
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/src/screens/CapsulePicturePage.tsx
+++ b/src/screens/CapsulePicturePage.tsx
@@ -1,11 +1,109 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  FlatList,
+  Dimensions,
+} from 'react-native';
 
-export default function CapsulePicturePage() {
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const HORIZONTAL_PADDING = 24;
+const ITEM_MARGIN = 12;
+const NUM_COLUMNS = 4;
+const PREVIEW_SIZE = SCREEN_WIDTH - HORIZONTAL_PADDING * 2;
 
+const ITEM_SIZE =
+  (SCREEN_WIDTH - HORIZONTAL_PADDING * 2 - ITEM_MARGIN * (NUM_COLUMNS - 1)) /
+  NUM_COLUMNS;
+
+const dummyData = Array.from({ length: 16 }, (_, i) => ({ id: i.toString() }));
+
+const CapsulePicturePage: React.FC = () => {
   return (
-    <View>
-      <Text>타임캡슐-사진등록</Text>
+    <View style={styles.container}>
+      <View style={styles.topBar}>
+        <TouchableOpacity
+          accessibilityLabel="닫기"
+          activeOpacity={0.8}
+        >
+          <Text style={styles.closeText}>X</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.title}>사진/영상 선택</Text>
+
+        <TouchableOpacity
+          accessibilityLabel="다음으로 이동"
+          activeOpacity={0.8}
+        >
+          <Text style={styles.nextText}>다음</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.previewBox} />
+
+      <Text style={styles.recentText}>최근항목 ▼</Text>
+
+      <FlatList
+        data={dummyData}
+        numColumns={NUM_COLUMNS}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <View key={item.id} style={styles.imageBox} />}
+        columnWrapperStyle={{
+          justifyContent: 'space-between',
+          marginBottom: ITEM_MARGIN,
+        }}
+        showsVerticalScrollIndicator={false}
+      />
     </View>
   );
-}
+};
+
+export default CapsulePicturePage;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingTop: 50,
+    backgroundColor: 'white',
+  },
+  topBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  closeText: {
+    fontSize: 18,
+    color: '#333',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#333',
+  },
+  nextText: {
+    fontSize: 16,
+    color: '#007AFF',
+  },
+  previewBox: {
+    width: PREVIEW_SIZE,
+    height: PREVIEW_SIZE,
+    backgroundColor: '#D9D9D9',
+    borderRadius: 20,
+    marginBottom: 20,
+  },
+  recentText: {
+    fontSize: 12,
+    color: '#666',
+    marginBottom: 12,
+  },
+  imageBox: {
+    width: ITEM_SIZE,
+    height: ITEM_SIZE,
+    backgroundColor: '#D9D9D9',
+    borderRadius: 12,
+  },
+});


### PR DESCRIPTION
# 타임캡슐 메인·사진등록 UI 구현

## 😺 Issue
- #12 

## ✅ 작업 리스트
- 타임캡슐 메인페이지 텍스트 UI 구성
- 타임캡슐 메인페이지 아이콘 UI 구현
- 타임캡슐 메인페이지 시작하기 버튼 UI 구현
- 사진등록 페이지 상단 헤더 구성
- 사진등록 페이지 대표 이미지 프리뷰 박스 UI 구현
- 사진등록 페이지 이미지 그리드 UI 구현

## ⚙️ 작업 내용
- 타임캡슐 메인 페이지 레이아웃 구현
  - 타이틀, 서브타이틀, 프리뷰 박스, 시작하기 버튼 구성
- 타임캡슐 사진 등록 페이지 레이아웃 구현
  - 상단 TopBar, 프리뷰 박스, 최근 항목 텍스트, 이미지 선택 그리드 구성

## 📷 테스트 / 구현 내용
- 타임캡슐
![CapsuleMainPage](https://github.com/user-attachments/assets/57c550ef-771e-4a9c-b460-b4a5733c0600)

-타임캡슐 (사진등록)
![CapsulePicturePage](https://github.com/user-attachments/assets/405213c0-1738-4e00-a91b-bcce39d15e6a)

