### PR TITLE
[feat] CapsuleFormPage 사진 넘겨받기 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@react-native-camera-roll/camera-roll": "^7.10.1",
     "@gorhom/bottom-sheet": "^5.1.6",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-camera-roll/camera-roll": "^7.10.1",
     "@react-native-community/datetimepicker": "^8.4.2",
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-native-seoul/kakao-login": "^5.4.1",

--- a/src/screens/CapsuleFormPage.tsx
+++ b/src/screens/CapsuleFormPage.tsx
@@ -15,13 +15,19 @@ import { CaretLeft } from 'phosphor-react-native';
 import CustomButton from '../components/UI/CustomButton';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import LinearGradient from 'react-native-linear-gradient';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { CapsuleStackParamList } from '../store/types';
 
 import { useCurrentCoords } from '../hooks/useCurrentCoords';
 import { getAddressFromCoords } from '../utils/getAdressFromCoords';
 
+type CapsuleFormPageRouteProp = RouteProp<CapsuleStackParamList, 'CapsuleFormPage'>;
+
 export default function CapsuleFormPage() {
+  const route = useRoute<CapsuleFormPageRouteProp>();
+  const { imageUris = [] } = route.params ?? {};
+
   const [CapsuleOpenVisible, setCapsuleOpenVisible] = useState(false);
 
   const [OpenAtDate, setOpenAtDate] = useState(new Date());
@@ -34,7 +40,7 @@ export default function CapsuleFormPage() {
   const [CapsuleDescribe, setCapsuleDescribe] = useState('');
   const [selectedType, setSelectedType] = useState<'normal' | 'time'>('normal');
 
-  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const navigation = useNavigation<NativeStackNavigationProp<CapsuleStackParamList>>();
 
   const { coords, isLoadingLocation, getLocation } = useCurrentCoords();
   const [address, setAddress] = useState<string | null>(null);
@@ -91,9 +97,14 @@ export default function CapsuleFormPage() {
         <View className='flex-1 items-start px-[20px] space-y-[10px]'>
           <View className="w-screen px-[20px] pb-[24px] border-b border-gray-400 self-center">
             <View className="flex-row">
-              <View className="w-[80px] h-[80px] rounded-xl bg-gray-300 mr-[12px]" />
-              <View className="w-[80px] h-[80px] rounded-xl bg-gray-300 mr-[12px]" />
-              <View className="w-[80px] h-[80px] rounded-xl bg-gray-300" />
+              {imageUris.slice(0, 3).map((uri: string, index: number) => (
+                <Image
+                  key={index}
+                  source={{ uri }}
+                  className="w-[80px] h-[80px] rounded-xl mr-[12px]"
+                  resizeMode="cover"
+                />  
+              ))}
             </View>
           </View>
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -4,7 +4,9 @@ export type CapsuleStackParamList = {
   CapsuleIndexPage: undefined;
   CapsuleMainPage: undefined;
   CapsulePicturePage: undefined;
-  CapsuleFormPage: undefined;
+  CapsuleFormPage: {
+    imageUris: string[];
+  };
   CapsuleUploadPage: undefined;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,6 +1538,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gorhom/bottom-sheet@npm:^5.1.6":
+  version: 5.1.6
+  resolution: "@gorhom/bottom-sheet@npm:5.1.6"
+  dependencies:
+    "@gorhom/portal": "npm:1.0.14"
+    invariant: "npm:^2.2.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-native": "*"
+    react: "*"
+    react-native: "*"
+    react-native-gesture-handler: ">=2.16.1"
+    react-native-reanimated: ">=3.16.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-native":
+      optional: true
+  checksum: 10c0/2f5c7e4e0a8968a567f5dcac5553b85e09850be46755bcf10a6e44843705392dd71c701b551575d8ea7c6cda8678f4a04851e926b6bfa63e82198b88568a76d8
+  languageName: node
+  linkType: hard
+
+"@gorhom/portal@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@gorhom/portal@npm:1.0.14"
+  dependencies:
+    nanoid: "npm:^3.3.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/86f33afc2ac2656a86a6f3fd1e41565419839576ede2c38333434a93a0a2fe4fb6fc18ab3360579427f2a1fc3b4564b933cc5ae1793a7e2825c93860a00b215f
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -1990,13 +2024,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-camera-roll/camera-roll@npm:^7.10.1":
-  version: 7.10.1
-  resolution: "@react-native-camera-roll/camera-roll@npm:7.10.1"
-  peerDependencies:
-    react-native: ">=0.59"
-  checksum: 10c0/96fb8e1135c330f187a8a0e20b9a5a0d9aa3f29865a2d5c3a9123f3d639e53063ba081c282ab22ffa2c2744c0fd89bf1713e6e33f2b5e975fade4eb032408249
-
 "@react-native-async-storage/async-storage@npm:^2.2.0":
   version: 2.2.0
   resolution: "@react-native-async-storage/async-storage@npm:2.2.0"
@@ -2005,6 +2032,15 @@ __metadata:
   peerDependencies:
     react-native: ^0.0.0-0 || >=0.65 <1.0
   checksum: 10c0/84900eba46a40225c4ac9bf5eb58885200dc1e789d873ecda46a2a213870cc7110536ed1fd7a74b873071f3603c093958fbd84c635d6f6d4f94bfbb616ffa0ef
+  languageName: node
+  linkType: hard
+
+"@react-native-camera-roll/camera-roll@npm:^7.10.1":
+  version: 7.10.1
+  resolution: "@react-native-camera-roll/camera-roll@npm:7.10.1"
+  peerDependencies:
+    react-native: ">=0.59"
+  checksum: 10c0/96fb8e1135c330f187a8a0e20b9a5a0d9aa3f29865a2d5c3a9123f3d639e53063ba081c282ab22ffa2c2744c0fd89bf1713e6e33f2b5e975fade4eb032408249
   languageName: node
   linkType: hard
 
@@ -7044,9 +7080,9 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/runtime": "npm:^7.25.0"
-    "@react-native-camera-roll/camera-roll": "npm:^7.10.1"
     "@gorhom/bottom-sheet": "npm:^5.1.6"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"
+    "@react-native-camera-roll/camera-roll": "npm:^7.10.1"
     "@react-native-community/cli": "npm:18.0.0"
     "@react-native-community/cli-platform-android": "npm:18.0.0"
     "@react-native-community/cli-platform-ios": "npm:18.0.0"
@@ -7536,7 +7572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
+"nanoid@npm:^3.3.1, nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -8497,7 +8533,7 @@ __metadata:
   checksum: 10c0/cd41bf28e9f468173f1e5e768685128ebf8bbf9077710e43b63482c1a76f37bff8ab3d1d6adfd7b4d54e648672356c02bea46c47cdbdb1844ebe5c5caf720114
   languageName: node
   linkType: hard
-  
+
 "react-native-permissions@npm:^5.4.1":
   version: 5.4.1
   resolution: "react-native-permissions@npm:5.4.1"
@@ -8547,7 +8583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:^5.5.1":
+"react-native-safe-area-context@npm:^5.5.2":
   version: 5.5.2
   resolution: "react-native-safe-area-context@npm:5.5.2"
   peerDependencies:


### PR DESCRIPTION
## 😺 Issue
- #28

## ✅ 작업 리스트
- CapsulePicturePage에서 선택한 사진들을 CapsuleFormPage로 넘겨주기 기능추가

## ⚙️ 작업 내용
- CapsulePicturePage의 goToForm 함수로 CapsuleFormPage에서 사진 url 을 imageUris로 넘겨받아서 사용

## 📷 테스트 / 구현 내용
<img width="324" height="685" alt="스크린샷 2025-07-20 오전 12 25 26" src="https://github.com/user-attachments/assets/0d8883ac-b43b-4f26-8170-337d09ac639b" />